### PR TITLE
 Bug fixes, many improvements, and updates to match offical repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ python train.py --name experiment_1 --resolution 512 --batch-size 8 --diff-aug
 
 ## Differences from the paper
 
-- Instead of random cropping to get `I_{part}` now only center cropping is implemented
+- ~~Instead of random cropping to get `I_{part}` now only center cropping is implemented~~ Random cropping is implemented under the name center cropping
 - Optionally you can use [Differentiable Augmentations](https://arxiv.org/abs/2006.10738) (`--diff-augment`)
 
 ### Not mentioned in the paper

--- a/sle_gan/__init__.py
+++ b/sle_gan/__init__.py
@@ -3,6 +3,7 @@ from .data import create_input_noise, create_dataset, postprocess_images, center
 from .diff_augment import diff_augment
 from .evaluation.fid import calculate_FID, InceptionModel
 from .losses import generator_loss, discriminator_reconstruction_loss, discriminator_real_fake_loss
+from .lpips_tf import lpips
 from .network.discriminator import Discriminator
 from .network.generator import Generator
 from .training_routine import train_step, evaluation_step

--- a/sle_gan/losses.py
+++ b/sle_gan/losses.py
@@ -1,8 +1,13 @@
 import tensorflow as tf
-
+from .lpips_tf import lpips
 
 def discriminator_reconstruction_loss(real_image, decoded_image):
-    return tf.reduce_mean(tf.keras.losses.MAE(real_image, decoded_image))
+    # replaced MAE loss with perception loss from official implementation. 
+
+    # expects images in [0,1] 
+    distance_percept = lpips((real_image + 1)/2, (decoded_image + 1)/2, model='net-lin', net='vgg')
+    return tf.reduce_mean(distance_percept)
+
 
 
 def discriminator_real_fake_loss(real_fake_output_logits_on_real_images, real_fake_output_logits_on_fake_images):

--- a/sle_gan/lpips_tf.py
+++ b/sle_gan/lpips_tf.py
@@ -1,0 +1,92 @@
+import os
+import sys
+
+import tensorflow as tf
+from six.moves import urllib
+
+"""
+Copied from: https://github.com/rlronan/lpips-tensorflow/blob/master/lpips_tf.py
+Which is a fork of https://github.com/alexlee-gk/lpips-tensorflow
+"""
+
+
+_URL = 'http://rail.eecs.berkeley.edu/models/lpips'
+
+
+def _download(url, output_dir):
+    """Downloads the `url` file into `output_dir`.
+    Modified from https://github.com/tensorflow/models/blob/master/research/slim/datasets/dataset_utils.py
+    """
+    filename = url.split('/')[-1]
+    filepath = os.path.join(output_dir, filename)
+
+    def _progress(count, block_size, total_size):
+        sys.stdout.write('\r>> Downloading %s %.1f%%' % (
+            filename, float(count * block_size) / float(total_size) * 100.0))
+        sys.stdout.flush()
+
+    filepath, _ = urllib.request.urlretrieve(url, filepath, _progress)
+    print()
+    statinfo = os.stat(filepath)
+    print('Successfully downloaded', filename, statinfo.st_size, 'bytes.')
+
+
+def lpips(input0, input1, model='net-lin', net='alex', version=0.1):
+    """
+    Learned Perceptual Image Patch Similarity (LPIPS) metric.
+    Args:
+        input0: An image tensor of shape `[..., height, width, channels]`,
+            with values in [0, 1].
+        input1: An image tensor of shape `[..., height, width, channels]`,
+            with values in [0, 1].
+    Returns:
+        The Learned Perceptual Image Patch Similarity (LPIPS) distance.
+    Reference:
+        Richard Zhang, Phillip Isola, Alexei A. Efros, Eli Shechtman, Oliver Wang.
+        The Unreasonable Effectiveness of Deep Features as a Perceptual Metric.
+        In CVPR, 2018.
+    """
+    # flatten the leading dimensions
+    batch_shape = tf.shape(input0)[:-3]
+    input0 = tf.reshape(input0, tf.concat([[-1], tf.shape(input0)[-3:]], axis=0))
+    input1 = tf.reshape(input1, tf.concat([[-1], tf.shape(input1)[-3:]], axis=0))
+    # NHWC to NCHW
+    input0 = tf.transpose(input0, [0, 3, 1, 2])
+    input1 = tf.transpose(input1, [0, 3, 1, 2])
+    # normalize to [-1, 1]
+    input0 = input0 * 2.0 - 1.0
+    input1 = input1 * 2.0 - 1.0
+
+    input0_name, input1_name = '0:0', '1:0'
+
+    default_graph = tf.compat.v1.get_default_graph()
+    producer_version = default_graph.graph_def_versions.producer
+
+    cache_dir = os.path.join(os.path.expanduser("~"), '.lpips')
+    os.makedirs(cache_dir, exist_ok=True)
+    # files to try. try a specific producer version, but fallback to the version-less version (latest).
+    pb_fnames = [
+        '%s_%s_v%s_%d.pb' % (model, net, version, producer_version),
+        '%s_%s_v%s.pb' % (model, net, version),
+    ]
+    for pb_fname in pb_fnames:
+        if not os.path.isfile(os.path.join(cache_dir, pb_fname)):
+            try:
+                _download(_URL + '/' + pb_fname, cache_dir)
+            except urllib.error.HTTPError:
+                pass
+        if os.path.isfile(os.path.join(cache_dir, pb_fname)):
+            break
+
+    with open(os.path.join(cache_dir, pb_fname), 'rb') as f:
+        graph_def = tf.compat.v1.GraphDef()
+        graph_def.ParseFromString(f.read())
+        _ = tf.compat.v1.import_graph_def(graph_def,
+                                input_map={input0_name: input0, input1_name: input1})
+        distance, = default_graph.get_operations()[-1].outputs
+
+    if distance.shape.ndims == 4:
+        distance = tf.squeeze(distance, axis=[-3, -2, -1])
+    # reshape the leading dimensions
+    distance = tf.reshape(distance, batch_shape)
+    return distance

--- a/sle_gan/network/discriminator.py
+++ b/sle_gan/network/discriminator.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
-
+import tensorflow_addons as tfa
+from tensorflow_addons.layers import SpectralNormalization as SN
 from sle_gan import center_crop_images
 from sle_gan.network.common_layers import GLU
 
@@ -18,11 +19,11 @@ class InputBlock(tf.keras.layers.Layer):
         if downsampling_factor == 1:
             conv_1_strides = 1
 
-        self.conv_1 = tf.keras.layers.Conv2D(filters=filters, kernel_size=4, strides=conv_1_strides, padding="same")
-        self.activation_1 = tf.keras.layers.LeakyReLU(0.1)
-        self.conv_2 = tf.keras.layers.Conv2D(filters=filters, kernel_size=4, strides=conv_2_strides, padding="same")
-        self.normalization = tf.keras.layers.BatchNormalization()
-        self.activation_2 = tf.keras.layers.LeakyReLU(0.1)
+        self.conv_1 = SN(tf.keras.layers.Conv2D(filters=filters, kernel_size=4, strides=conv_1_strides, padding="same", use_bias=False))
+        self.activation_1 = tf.keras.layers.LeakyReLU(0.2)
+        self.conv_2 = SN(tf.keras.layers.Conv2D(filters=filters, kernel_size=4, strides=conv_2_strides, padding="same", use_bias=False))
+        self.normalization = tf.keras.layers.LayerNormalization()
+        self.activation_2 = tf.keras.layers.LeakyReLU(0.2)
 
     def call(self, inputs, **kwargs):
         x = self.conv_1(inputs)
@@ -37,14 +38,14 @@ class DownSamplingBlock1(tf.keras.layers.Layer):
     def __init__(self, filters: int, **kwargs):
         super().__init__(**kwargs)
 
-        self.conv_1 = tf.keras.layers.Conv2D(filters=filters, kernel_size=4, strides=2, padding="same")
-        self.normalization_1 = tf.keras.layers.BatchNormalization()
-        self.activation_1 = tf.keras.layers.LeakyReLU(0.1)
+        self.conv_1 = SN(tf.keras.layers.Conv2D(filters=filters, kernel_size=4, strides=2, padding="same", use_bias=False))
+        self.normalization_1 = tf.keras.layers.LayerNormalization()
+        self.activation_1 = tf.keras.layers.LeakyReLU(0.2)
 
-        self.conv_2 = tf.keras.layers.Conv2D(filters=filters, kernel_size=3, strides=1, padding="same")
-        self.normalization_2 = tf.keras.layers.BatchNormalization()
-        self.activation_2 = tf.keras.layers.LeakyReLU(0.1)
-
+        self.conv_2 = SN(tf.keras.layers.Conv2D(filters=filters, kernel_size=3, strides=1, padding="same", use_bias=False))
+        self.normalization_2 = tf.keras.layers.LayerNormalization()
+        self.activation_2 = tf.keras.layers.LeakyReLU(0.2)
+    
     def call(self, inputs, **kwargs):
         x = self.conv_1(inputs)
         x = self.normalization_1(x)
@@ -60,9 +61,9 @@ class DownSamplingBlock2(tf.keras.layers.Layer):
         super().__init__(**kwargs)
 
         self.pooling = tf.keras.layers.AveragePooling2D(pool_size=(2, 2))
-        self.conv = tf.keras.layers.Conv2D(filters=filters, kernel_size=1, padding="valid")
-        self.normalization = tf.keras.layers.BatchNormalization()
-        self.activation = tf.keras.layers.LeakyReLU(0.1)
+        self.conv = SN(tf.keras.layers.Conv2D(filters=filters, kernel_size=1, padding="valid", use_bias=False))
+        self.normalization = tf.keras.layers.LayerNormalization()
+        self.activation = tf.keras.layers.LeakyReLU(0.2)
 
     def call(self, inputs, **kwargs):
         x = self.pooling(inputs)
@@ -75,22 +76,22 @@ class DownSamplingBlock2(tf.keras.layers.Layer):
 class DownSamplingBlock(tf.keras.layers.Layer):
     def __init__(self, filters, **kwargs):
         super().__init__(**kwargs)
-
+        self.filters = filters
         self.down_1 = DownSamplingBlock1(filters)
         self.down_2 = DownSamplingBlock2(filters)
 
     def call(self, inputs, **kwargs):
         x_1 = self.down_1(inputs)
         x_2 = self.down_2(inputs)
-        return x_1 + x_2
+        return (x_1 + x_2)/2 
 
 
 class SimpleDecoderBlock(tf.keras.layers.Layer):
     def __init__(self, output_filters, **kwargs):
         super().__init__(**kwargs)
         self.upsampling = tf.keras.layers.UpSampling2D(size=(2, 2), interpolation="nearest")
-        self.conv = tf.keras.layers.Conv2D(filters=output_filters * 2, kernel_size=3, padding="same")
-        self.normalization = tf.keras.layers.BatchNormalization()
+        self.conv = SN(tf.keras.layers.Conv2D(filters=output_filters * 2, kernel_size=3, padding="same", use_bias=False))
+        self.normalization = tf.keras.layers.LayerNormalization()
         self.glu = GLU()
 
     def call(self, inputs, **kwargs):
@@ -107,7 +108,7 @@ class SimpleDecoder(tf.keras.layers.Layer):
 
         self.decoder_block_filter_sizes = [256, 128, 128, 64]
         self.decoder_blocks = [SimpleDecoderBlock(output_filters=x) for x in self.decoder_block_filter_sizes]
-        self.conv_output = tf.keras.layers.Conv2D(3, 1, 1, padding="same")
+        self.conv_output = SN(tf.keras.layers.Conv2D(3, 1, 1, padding="same", use_bias=False))
 
     def call(self, inputs, **kwargs):
         x = inputs
@@ -122,10 +123,10 @@ class RealFakeOutputBlock(tf.keras.layers.Layer):
     def __init__(self, filters: int, **kwargs):
         super().__init__(**kwargs)
 
-        self.conv_1 = tf.keras.layers.Conv2D(filters=filters, kernel_size=1)
-        self.normalization = tf.keras.layers.BatchNormalization()
-        self.activation = tf.keras.layers.LeakyReLU(0.1)
-        self.conv_2 = tf.keras.layers.Conv2D(filters=1, kernel_size=4)
+        self.conv_1 = SN(tf.keras.layers.Conv2D(filters=filters, kernel_size=1))
+        self.normalization = tf.keras.layers.LayerNormalization()
+        self.activation = tf.keras.layers.LeakyReLU(0.2)
+        self.conv_2 = SN(tf.keras.layers.Conv2D(filters=1, kernel_size=4, use_bias=False))
 
     def call(self, inputs, **kwargs):
         x = self.conv_1(inputs)
@@ -134,6 +135,45 @@ class RealFakeOutputBlock(tf.keras.layers.Layer):
         x = self.conv_2(x)
         return x
 
+class SkipLayerExcitationBlock(tf.keras.layers.Layer):
+    """
+    Skip-Layer Excitation Block
+
+    This block receives 2 feature maps, a high and a low resolution one. Then transforms the low resolution feature map
+    and at the end it is multiplied along the channel dimension with the high resolution input.
+
+    E.g.:
+    Inputs:
+        - High_res shape: (B, 128, 128, 64)
+        - Low_res shape: (B, 8, 8, 512)
+    Output:
+        - shape: (B, 128, 128, 64)
+    """
+
+    def __init__(self, input_low_res_filters: int, input_high_res_filters: int, **kwargs):
+        super().__init__(**kwargs)
+
+        self.pooling = tfa.layers.AdaptiveAveragePooling2D(output_size=(4, 4), data_format="channels_last")
+        self.conv2d_1 = SN(tf.keras.layers.Conv2D(filters=input_low_res_filters,
+                                               kernel_size=(4, 4),
+                                               strides=1,
+                                               padding="valid", use_bias=False))
+        #replace with silu (aka swift)
+        self.conv2d_2 = SN(tf.keras.layers.Conv2D(filters=input_high_res_filters,
+                                               kernel_size=(1, 1),
+                                               strides=1,
+                                               padding="valid", use_bias=False))
+
+    def call(self, inputs, **kwargs):
+        x_low, x_high = inputs
+
+        x = self.pooling(x_low)
+        x = self.conv2d_1(x)
+        x = tf.nn.silu(x)
+        x = self.conv2d_2(x)
+        x = tf.nn.sigmoid(x)
+
+        return x * x_high
 
 class Discriminator(tf.keras.models.Model):
     def __init__(self, input_resolution: int, *args, **kwargs):
@@ -146,38 +186,51 @@ class Discriminator(tf.keras.models.Model):
         self.input_block = InputBlock(filters=input_block_filters_dict[input_resolution],
                                       downsampling_factor=downsampling_factor_dict[input_resolution])
 
-        self.downsample_128 = DownSamplingBlock(filters=64)
-        self.downsample_64 = DownSamplingBlock(filters=128)
-        self.downsample_32 = DownSamplingBlock(filters=128)
-        self.downsample_16 = DownSamplingBlock(filters=256)
-        self.downsample_8 = DownSamplingBlock(filters=512)
+        self.downsample_128 = DownSamplingBlock(filters=64) #should be 32
+        self.downsample_64 = DownSamplingBlock(filters=128) #should be 64
+        self.downsample_32 = DownSamplingBlock(filters=128) #should be 128
+        self.downsample_16 = DownSamplingBlock(filters=256) #should be 256
+        self.downsample_8 = DownSamplingBlock(filters=512)  #should be 512
 
+        # added sle blocks into discriminator per official implementation.
+        self.sle_in_32 = SkipLayerExcitationBlock(256, self.downsample_32.filters)
+        self.sle_128_16 = SkipLayerExcitationBlock(self.downsample_128.filters, self.downsample_16.filters)
+        self.sle_64_8 = SkipLayerExcitationBlock(self.downsample_64.filters, self.downsample_8.filters)
+    
+        #TODO: self.decoder_big 
         self.decoder_image_part = SimpleDecoder()
         self.decoder_image = SimpleDecoder()
 
         self.real_fake_output = RealFakeOutputBlock(filters=256)
 
     def initialize(self, batch_size: int = 1):
-        sample_input = tf.random.uniform(shape=(batch_size, self.input_resolution, self.input_resolution, 3), minval=0,
+        sample_input = tf.random.uniform(shape=(batch_size, self.input_resolution, self.input_resolution, 3), minval=-1,
                                          maxval=1, dtype=tf.float32)
         sample_output = self.call(sample_input)
         return sample_output
 
     @tf.function
     def call(self, inputs, training=None, mask=None):
-        x = self.input_block(inputs)  # --> (B, 256, 256, F)
-
-        x = self.downsample_128(x)  # --> (B, 128, 128, 64)
-        x = self.downsample_64(x)  # --> (B, 64, 64, 128)
-        x = self.downsample_32(x)  # --> (B, 32, 32, 128)
-        x_16 = self.downsample_16(x)  # --> (B, 16, 16, 256)
+        
+        x_in = self.input_block(inputs)  # --> (B, 256, 256, F)
+        x_128 = self.downsample_128(x_in)  # --> (B, 128, 128, 64)
+        x_64 = self.downsample_64(x_128)  # --> (B, 64, 64, 128)
+        
+        x_32 = self.downsample_32(x_64)  # --> (B, 32, 32, 128)
+        x_sle_32 = self.sle_in_32([x_in, x_32])
+        
+        x_16 = self.downsample_16(x_sle_32)  # --> (B, 16, 16, 256)
+        x_sle_16 = self.sle_128_16([x_128, x_16])
+        
         x_8 = self.downsample_8(x_16)  # --> (B, 8, 8, 512)
-
-        # TODO: instead of just center cropping implement random cropping
-        center_cropped_x_16 = center_crop_images(x_16, 8)  # --> (B, 8, 8, 64)
+        x_sle_8 = self.sle_64_8([x_64, x_8])
+        
+        # Implemented random cropping but left name.
+        # DONE: instead of just center cropping implement random cropping
+        center_cropped_x_16 = center_crop_images(x_sle_16, 8)  # --> (B, 8, 8, 64)
         x_image_decoded_128_center_part = self.decoder_image_part(center_cropped_x_16)  # --> (B, 128, 128, 3)
-        x_image_decoded_128 = self.decoder_image(x_8)  # --> (B, 128, 128, 3)
+        x_image_decoded_128 = self.decoder_image(x_sle_8)  # --> (B, 128, 128, 3)
 
-        x_real_fake_logits = self.real_fake_output(x_8)  # --> (B, 5, 5, 1)
+        x_real_fake_logits = self.real_fake_output(x_sle_8)  # --> (B, 5, 5, 1)
 
         return x_real_fake_logits, x_image_decoded_128, x_image_decoded_128_center_part

--- a/sle_gan/network/discriminator.py
+++ b/sle_gan/network/discriminator.py
@@ -222,7 +222,7 @@ class Discriminator(tf.keras.models.Model):
         x_16 = self.downsample_16(x_sle_32)  # --> (B, 16, 16, 256)
         x_sle_16 = self.sle_128_16([x_128, x_16])
         
-        x_8 = self.downsample_8(x_16)  # --> (B, 8, 8, 512)
+        x_8 = self.downsample_8(x_sle_16)  # --> (B, 8, 8, 512)
         x_sle_8 = self.sle_64_8([x_64, x_8])
         
         # Implemented random cropping but left name.

--- a/sle_gan/training_routine.py
+++ b/sle_gan/training_routine.py
@@ -9,17 +9,17 @@ import sle_gan
 @tf.function
 def train_step(G, D, G_optimizer, D_optimizer, images, diff_augmenter_policies: str = None) -> tuple:
     batch_size = tf.shape(images)[0]
-
+    
     # Images for the I_{part} reconstruction loss
     images_batch_center_crop_128 = sle_gan.center_crop_images(images, 128)
 
     # Images for the I reconstruction loss
-    image_batch_128 = tf.image.resize(images, (128, 128))
+    image_batch_128 = tf.image.resize(images, (128, 128), method='nearest')
 
     with tf.GradientTape() as tape_G, tf.GradientTape() as tape_D:
         noise_input = sle_gan.create_input_noise(batch_size)
         generated_images = G(noise_input, training=True)
-
+        
         real_fake_output_logits_on_real_images, decoded_real_image, decoded_real_image_central_crop = D(
             sle_gan.diff_augment(images, policy=diff_augmenter_policies), training=True)
         real_fake_output_logits_on_fake_images, _, _ = D(
@@ -44,7 +44,7 @@ def train_step(G, D, G_optimizer, D_optimizer, images, diff_augmenter_policies: 
 
     D_optimizer.apply_gradients(zip(D_gradients, D.trainable_variables))
     G_optimizer.apply_gradients(zip(G_gradients, G.trainable_variables))
-
+  
     return G_loss, D_loss, D_real_fake_loss, D_I_reconstruction_loss, D_I_part_reconstruction_loss
 
 


### PR DESCRIPTION
## Fixes:
- Moved model weight loading into the training loop in train.py, so it works properly. The model needs to be initialized for the weights to be loaded.
- Fixed code for Discriminator weight loading. 
- Divided DownSamplingBlock output by two so that it is an average of the two sub-outputs, rather than a sum.

## Updates:
- Added Tensorboard metric logging for every step, rather than just every epoch.
- Added Visualizations at every 500 steps if the epoch is longer than 500 steps.
- Changed image resizing in training_routine.py to use 'nearest' method since the resizing is by a factor of 1/2. 
- create_dataset function now also tries to find .png files if no .jpg files are found. 
- center_crop_image function now performs random crops, but is still called 'center_crop_images'
- Replaced BatchNormalization with LayerNormalization everywhere, as it is more appropriate to use with small batch sizes. 
- Updated tensorboard logging to take steps rather than epochs. 

## Updates to match official implementation
- Replaced reconstruction loss MAE function with perception loss as per the official repository implementation, and because MAE is not a good image distance metric.  
- Included a forked version of https://github.com/alexlee-gk/lpips-tensorflow  which i updated for TF2.x to perform the perception loss.
- In the discriminator, added a spectral norm wrapper to every conv layer, and updated leakyrelu rate to 0.2
- In the discriminator, added SLE blocks as per the official repository; this should improve the gradient flow in the discriminator. 
- In the generator, included the code for upsampling blocks that match the official repository (under UpsamplingBlock2). These have a small amount of Gaussian noise added, and are twice as many layers as the current UpsamplingBlock. In the official repository, both types of upsampling blocks are interspersed.  
- Turned bias off for every conv layer in the discriminator and generator.
- Replaced leakyrelu with silu (aka swift) activation function in SLE blocks.